### PR TITLE
Fix dir()

### DIFF
--- a/NukeSurvivalToolkit/init.py
+++ b/NukeSurvivalToolkit/init.py
@@ -21,8 +21,8 @@ for root, dirs, files in os.walk(NST_FolderPath):
     # ignore any folder that states with these characters
     dirs[:] = [d for d in dirs if not d.startswith('.') and not d.startswith('_')]
     #create whiteList
-    for dir in dirs:
-        whiteList.append( os.path.join(root, dir) )
+    for dir_name in dirs:
+        whiteList.append( os.path.join(root, dir_name) )
 
 # add plugin paths
 print ("""


### PR DESCRIPTION
Currently if you install NST, dir() in the Script Editor breaks as it's being overridden by dir in the for loop.

Changing dir to dir_name in both instances fixes this