### PR TITLE
fix backslash issue

### DIFF
--- a/NukeSurvivalToolkit/menu.py
+++ b/NukeSurvivalToolkit/menu.py
@@ -25,7 +25,7 @@ global prefixNST
 prefixNST = "NST_"
 
 # Store the location of this menu.py to help with nuke.nodePaste() which requires a filepath to paste
-NST_FolderPath = os.path.dirname(__file__)
+NST_FolderPath = os.path.normpath(os.path.dirname(__file__))
 NST_helper.NST_FolderPath = NST_FolderPath
 
 # give the name of the help doc .pdf in main folder


### PR DESCRIPTION
This is a fix for the issue #18.

`os.path.normpath` is an easy way to fix pathing issues between Windows and Mac/Linux