### PR TITLE
replaced os.join with Path objects for cross platform compatability

### DIFF
--- a/NukeSurvivalToolkit/menu.py
+++ b/NukeSurvivalToolkit/menu.py
@@ -10,6 +10,8 @@ import sys
 import os
 import webbrowser
 
+from pathlib import Path
+
 # Add PluginPaths to tools and icons
 nuke.pluginAddPath('./gizmos')
 nuke.pluginAddPath('./python')
@@ -25,7 +27,7 @@ global prefixNST
 prefixNST = "NST_"
 
 # Store the location of this menu.py to help with nuke.nodePaste() which requires a filepath to paste
-NST_FolderPath = os.path.dirname(__file__)
+NST_FolderPath = Path(__file__).parent.as_posix()
 NST_helper.NST_FolderPath = NST_FolderPath
 
 # give the name of the help doc .pdf in main folder
@@ -77,69 +79,69 @@ expressionMenu.addMenu( 'Transform', icon = os.path.join(NST_FolderPath, "icons/
 expressionMenu.addMenu( '3D and Deep', icon = os.path.join(NST_FolderPath, "icons/expr_06.png") )
 
 #CREATIONS
-expressionMenu.addCommand('Creations/Random/Random Colors', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Random_colors.nk") + "\")")
-expressionMenu.addCommand('Creations/Random/Random every Frame', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Random_every_frame.nk") + "\")")
-expressionMenu.addCommand('Creations/Random/Random every Pixel', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Random_every_pixel.nk") + "\")")
-#expressionMenu.addCommand('Creations/Noise/Noise', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Noise.nk") + "\")")
-#expressionMenu.addCommand('Creations/Noise/fBm', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/fBm.nk") + "\")")
-#expressionMenu.addCommand('Creations/Noise/Turbulence', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/turbulence.nk") + "\")")
-expressionMenu.addCommand('Creations/lines vertical', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Lines_Vertical.nk") + "\")")
-expressionMenu.addCommand('Creations/lines horizontal', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Lines_Horizontal.nk") + "\")")
-expressionMenu.addCommand('Creations/lines vertical animated', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Lines_Vertical_Animated.nk") + "\")")
-expressionMenu.addCommand('Creations/lines horizontal animated', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Lines_Horizontal_Animated.nk") + "\")")
-expressionMenu.addCommand('Creations/circles', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/circles.nk") + "\")")
-expressionMenu.addCommand('Creations/circles user', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/circles_user.nk") + "\")")
-expressionMenu.addCommand('Creations/points', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/points.nk") + "\")")
-expressionMenu.addCommand('Creations/points advanced', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/points_advanced.nk") + "\")")
-expressionMenu.addCommand('Creations/bricks', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/bricks.nk") + "\")")
-expressionMenu.addCommand('Creations/gradient horizontal', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/gradient_horizontal.nk") + "\")")
-expressionMenu.addCommand('Creations/gradient horizontal invert', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/gradient_horizontal_invert.nk") + "\")")
-expressionMenu.addCommand('Creations/gradient vertical', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/gradient_vertical.nk") + "\")")
-expressionMenu.addCommand('Creations/gradient vertical invert', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/gradient_vertical_invert.nk") + "\")")
-expressionMenu.addCommand('Creations/gradient 4 corners', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/GradientCorner.nk") + "\")")
-expressionMenu.addCommand('Creations/radial', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/radial.nk") + "\")")
-expressionMenu.addCommand('Creations/radial gradient', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/radial_gradient.nk") + "\")")
-expressionMenu.addCommand('Creations/radial rays', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/radial_rays.nk") + "\")")
-expressionMenu.addCommand('Creations/Trunc', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Trunc.nk") + "\")")
+expressionMenu.addCommand('Creations/Random/Random Colors', f"nuke.nodePaste('{NST_FolderPath + '/nk_files/Random_colors.nk'}')")
+expressionMenu.addCommand('Creations/Random/Random every Frame', f"nuke.nodePaste('{NST_FolderPath + '/nk_files/Random_every_frame.nk'}')")
+expressionMenu.addCommand('Creations/Random/Random every Pixel', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Random_every_pixel.nk'}')")
+#expressionMenu.addCommand('Creations/Noise/Noise', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Noise.nk'}')")
+#expressionMenu.addCommand('Creations/Noise/fBm', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/fBm.nk'}')")
+#expressionMenu.addCommand('Creations/Noise/Turbulence', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/turbulence.nk'}')")
+expressionMenu.addCommand('Creations/lines vertical', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Lines_Vertical.nk'}')")
+expressionMenu.addCommand('Creations/lines horizontal', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Lines_Horizontal.nk'}')")
+expressionMenu.addCommand('Creations/lines vertical animated', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Lines_Vertical_Animated.nk'}')")
+expressionMenu.addCommand('Creations/lines horizontal animated', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Lines_Horizontal_Animated.nk'}')")
+expressionMenu.addCommand('Creations/circles', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/circles.nk'}')")
+expressionMenu.addCommand('Creations/circles user', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/circles_user.nk'}')")
+expressionMenu.addCommand('Creations/points', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/points.nk'}')")
+expressionMenu.addCommand('Creations/points advanced', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/points_advanced.nk'}')")
+expressionMenu.addCommand('Creations/bricks', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/bricks.nk'}')")
+expressionMenu.addCommand('Creations/gradient horizontal', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/gradient_horizontal.nk'}')")
+expressionMenu.addCommand('Creations/gradient horizontal invert', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/gradient_horizontal_invert.nk'}')")
+expressionMenu.addCommand('Creations/gradient vertical', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/gradient_vertical.nk'}')")
+expressionMenu.addCommand('Creations/gradient vertical invert', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/gradient_vertical_invert.nk'}')")
+expressionMenu.addCommand('Creations/gradient 4 corners', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/GradientCorner.nk'}')")
+expressionMenu.addCommand('Creations/radial', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/radial.nk'}')")
+expressionMenu.addCommand('Creations/radial gradient', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/radial_gradient.nk'}')")
+expressionMenu.addCommand('Creations/radial rays', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/radial_rays.nk'}')")
+expressionMenu.addCommand('Creations/Trunc', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Trunc.nk'}')")
 
 #ALPHA
-expressionMenu.addCommand('Alpha/alpha binary', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/alpha_binary.nk") + "\")")
-expressionMenu.addCommand('Alpha/alpha comparison', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/alpha_comparison.nk") + "\")")
-expressionMenu.addCommand('Alpha/alpha exists?', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/alpha_exists.nk") + "\")")
-expressionMenu.addCommand('Alpha/alpha sum', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/alpha_sum.nk") + "\")")
+expressionMenu.addCommand('Alpha/alpha binary', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/alpha_binary.nk'}')")
+expressionMenu.addCommand('Alpha/alpha comparison', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/alpha_comparison.nk'}')")
+expressionMenu.addCommand('Alpha/alpha exists?', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/alpha_exists.nk'}')")
+expressionMenu.addCommand('Alpha/alpha sum', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/alpha_sum.nk'}')")
 
 #PIXEL
-expressionMenu.addCommand('Pixel/absolute value', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/abs.nk") + "\")")
-expressionMenu.addCommand('Pixel/check negative', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/check_negative.nk") + "\")")
-expressionMenu.addCommand('Pixel/check nan inf pixels', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/check_nan_inf.nk") + "\")")
-expressionMenu.addCommand('Pixel/create nan pixel', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/create_nan.nk") + "\")")
-expressionMenu.addCommand('Pixel/kill nan pixel', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/kill_nan.nk") + "\")")
-expressionMenu.addCommand('Pixel/create inf pixel', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/create_inf.nk") + "\")")
-expressionMenu.addCommand('Pixel/kill inf pixel', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/kill_inf.nk") + "\")")
+expressionMenu.addCommand('Pixel/absolute value', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/abs.nk'}')")
+expressionMenu.addCommand('Pixel/check negative', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/check_negative.nk'}')")
+expressionMenu.addCommand('Pixel/check nan inf pixels', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/check_nan_inf.nk'}')")
+expressionMenu.addCommand('Pixel/create nan pixel', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/create_nan.nk'}')")
+expressionMenu.addCommand('Pixel/kill nan pixel', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/kill_nan.nk'}')")
+expressionMenu.addCommand('Pixel/create inf pixel', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/create_inf.nk'}')")
+expressionMenu.addCommand('Pixel/kill inf pixel', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/kill_inf.nk'}')")
 
 #TRANSFORM
-expressionMenu.addCommand('Transform/Coordinates', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/coordinates.nk") + "\")")
-expressionMenu.addCommand('Transform/UV to Vector', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/UV_to_Vector.nk") + "\")")
-expressionMenu.addCommand('Transform/Vector to UV', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/Vector_to_UV.nk") + "\")")
-expressionMenu.addCommand('Transform/transform', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/transform.nk") + "\")")
-expressionMenu.addCommand('Transform/transform advanced', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/transform_advanced.nk") + "\")")
-expressionMenu.addCommand('Transform/twist', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/twist.nk") + "\")")
-expressionMenu.addCommand('Transform/STMap_invert', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/STMap_invert.nk") + "\")")
+expressionMenu.addCommand('Transform/Coordinates', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/coordinates.nk'}')")
+expressionMenu.addCommand('Transform/UV to Vector', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/UV_to_Vector.nk'}')")
+expressionMenu.addCommand('Transform/Vector to UV', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/Vector_to_UV.nk'}')")
+expressionMenu.addCommand('Transform/transform', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/transform.nk'}')")
+expressionMenu.addCommand('Transform/transform advanced', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/transform_advanced.nk'}')")
+expressionMenu.addCommand('Transform/twist', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/twist.nk'}')")
+expressionMenu.addCommand('Transform/STMap_invert', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/STMap_invert.nk'}')")
 
 #3D and DEEP
-expressionMenu.addCommand('3D and Deep/Normal Pass - Relight', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/normalPass_relight.nk") + "\")")
-expressionMenu.addCommand('3D and Deep/C4x4', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/C4x4.nk") + "\")")
-expressionMenu.addCommand('3D and Deep/Deep to Depth', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/deepToDepth.nk") + "\")")
-expressionMenu.addCommand('3D and Deep/Depth normalize', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/depth_normalize.nk") + "\")")
+expressionMenu.addCommand('3D and Deep/Normal Pass - Relight', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/normalPass_relight.nk'}')")
+expressionMenu.addCommand('3D and Deep/C4x4', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/C4x4.nk'}')")
+expressionMenu.addCommand('3D and Deep/Deep to Depth', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/deepToDepth.nk'}')")
+expressionMenu.addCommand('3D and Deep/Depth normalize', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/depth_normalize.nk'}')")
 
 #KEYING and DESPILL
-expressionMenu.addCommand('Keying and Despill/despill green', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/despill_green.nk") + "\")")
-expressionMenu.addCommand('Keying and Despill/despill green list', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/despill_green_list.nk") + "\")")
-expressionMenu.addCommand('Keying and Despill/despill blue', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/despill_blue.nk") + "\")")
-expressionMenu.addCommand('Keying and Despill/despill blue list', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/despill_blue_list.nk") + "\")")
-expressionMenu.addCommand('Keying and Despill/keying', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/keying.nk") + "\")")
-expressionMenu.addCommand('Keying and Despill/differenceKey', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/differenceKey.nk") + "\")")
-expressionMenu.addCommand('Keying and Despill/IBKGizmo_Expression', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/IBKGizmo_Expression.nk") + "\")")
+expressionMenu.addCommand('Keying and Despill/despill green', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/despill_green.nk'}')")
+expressionMenu.addCommand('Keying and Despill/despill green list', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/despill_green_list.nk'}')")
+expressionMenu.addCommand('Keying and Despill/despill blue', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/despill_blue.nk'}')")
+expressionMenu.addCommand('Keying and Despill/despill blue list', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/despill_blue_list.nk'}')")
+expressionMenu.addCommand('Keying and Despill/keying', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/keying.nk'}')")
+expressionMenu.addCommand('Keying and Despill/differenceKey', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/differenceKey.nk'}')")
+expressionMenu.addCommand('Keying and Despill/IBKGizmo_Expression', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/IBKGizmo_Expression.nk'}')")
 
 expressionMenu.addSeparator()
 
@@ -604,7 +606,7 @@ deepMenu.addCommand('DeepToPosition TL', "nuke.createNode('{}DeepToPosition')".f
 deepMenu.addCommand('DeepRecolorMatte TL', "nuke.createNode('{}DeepRecolorMatte')".format(prefixNST), icon="DeepRecolor.png")
 
 deepMenu.addSeparator()
-deepMenu.addCommand('Deep Thickness AG', "nuke.nodePaste(\"" + os.path.join(NST_FolderPath + "/nk_files/deepThickness.nk") + "\")")
+deepMenu.addCommand('Deep Thickness AG', f"nuke.nodePaste('{NST_FolderPath + 'nk_files/deepThickness.nk'}')")
 deepMenu.addCommand('DeepMerge_Advanced BM', "nuke.createNode('{}DeepMerge_Advanced')".format(prefixNST), icon="DeepMerge.png")
 deepMenu.addCommand('DeepCropSoft NKPD', "nuke.createNode('{}DeepCropSoft')".format(prefixNST), icon="DeepCrop.png")
 deepMenu.addCommand('DeepKeyMix NKPD', "nuke.createNode('{}DeepKeyMix')".format(prefixNST), icon="DeepMerge.png")


### PR DESCRIPTION
Posix paths can be used by nuke in both posix environments (linux, macos), and Windows environments. Using f strings also makes those nodePaste calls a little more readable as well, in my opinion.

There are other places where one could replace the os calls, but they all seem to work just fine in all environments so I left them alone.